### PR TITLE
buster: use iptables-legacy instead of iptables-nft

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -113,7 +113,9 @@ dist_upgrade() {
 
     differed_action pre-start
     wazo-service enable
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
     wazo-service restart
+    update-alternatives --set iptables /usr/sbin/iptables-nft
     differed_action post-start
     apt-get purge --yes xivo-dist
 }


### PR DESCRIPTION
reason: after the upgrade, the rule added by wazo-service blocking SIP
port is still in effect