### PR TITLE
wazo-dist-upgrade-stretch: handle upgrade from wazo 17.17 to wazo 19.12

### DIFF
--- a/bin/wazo-dist-upgrade-stretch
+++ b/bin/wazo-dist-upgrade-stretch
@@ -56,7 +56,8 @@ differed_action() {
     echo "Executing $state upgrade action..."
     export XIVO_VERSION_INSTALLED=17.17
     shopt -qs nullglob  # avoid warning when action directory has no scripts
-    for script in /usr/share/wazo-dist-upgrade/$state.d/* ; do
+    for script in /usr/share/xivo-upgrade/$state.d/* ; do
+        echo "Executing upgrade script $script..."
         $script
     done
     shopt -qu nullglob

--- a/bin/wazo-dist-upgrade-stretch
+++ b/bin/wazo-dist-upgrade-stretch
@@ -103,6 +103,7 @@ dist_upgrade() {
 
     apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-certs xivo-config
     systemctl restart consul
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" wazo-platform
     apt-get upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get dist-upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get autoremove --yes

--- a/bin/wazo-dist-upgrade-stretch
+++ b/bin/wazo-dist-upgrade-stretch
@@ -91,16 +91,18 @@ change_sources_list() {
 
 dist_upgrade() {
     apt-get update -qq
-    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-dist xivo-upgrade
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-dist
+
+    xivo-dist ${wazo_distribution}
+    change_sources_list 'jessie' 'stretch'
+
+    apt-get update -qq
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-upgrade
 
     differed_action pre-stop
     wazo-service stop
     wazo-service disable
     differed_action post-stop
-
-    xivo-dist ${wazo_distribution}
-    change_sources_list 'jessie' 'stretch'
-    apt-get update -qq
 
     apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-certs xivo-config
     systemctl restart consul

--- a/bin/wazo-dist-upgrade-stretch
+++ b/bin/wazo-dist-upgrade-stretch
@@ -26,7 +26,7 @@ wazo_version_installed() {
 }
 
 wazo_version_candidate() {
-    echo "$(LANG='C' apt-cache policy xivo | grep Candidate | grep -oE '[0-9]{2}\.[0-9]+(\.[0-9]+)?' | head -n1)"
+    echo "$(LANG='C' apt-cache policy wazo-platform | grep Candidate | grep -oE '[0-9]{2}\.[0-9]+(\.[0-9]+)?' | head -n1)"
 }
 
 display_upgrade_notice() {

--- a/bin/wazo-dist-upgrade-stretch
+++ b/bin/wazo-dist-upgrade-stretch
@@ -89,13 +89,13 @@ change_sources_list() {
 }
 
 dist_upgrade() {
+    apt-get update -qq
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-dist xivo-upgrade
+
     differed_action pre-stop
     wazo-service stop
     wazo-service disable
     differed_action post-stop
-
-    apt-get update -qq
-    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-dist
 
     xivo-dist ${wazo_distribution}
     change_sources_list 'jessie' 'stretch'


### PR DESCRIPTION
reason: we need the pre/post stop scripts from the latest xivo-upgrade
in pelican-stretch, but we don't want to copy xivo-upgrade from stretch
to jessie because it is a pain to maintain scripts for jessie while
developing stretch.