### PR TITLE
buster: do not install recommends for xivo-dbms

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 LOGFILE="/var/log/wazo-upgrade.log"
@@ -162,7 +162,7 @@ dist_upgrade() {
     apt-get update -qq
 
     apt-get install --yes -o Dpkg::Options::="--force-confnew" wazo-dist
-    apt-get install --yes -o Dpkg::Options::="--force-confnew" xivo-dbms  # Handle PostgreSQL cluster upgrade
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends xivo-dbms  # Handle PostgreSQL cluster upgrade
     apt-get install --yes -o Dpkg::Options::="--force-confnew" systemd systemd-sysv  # Fix rabbitmq-server.service obscure bug
     migrate_systemd_system_conf
     apt-get install --yes -o Dpkg::Options::="--force-confnew" rabbitmq-server


### PR DESCRIPTION
reason: if postgresql-9.6 recommend package (sysstat) is not installed
(generally on new install without having upgraded pg), then the new
sysstat buster will break other packages (before upgrading them to
buster)
See JIRA WAZO-1727 for more info