### PR TITLE
rename xivo-dbms to wazo-dbms

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -147,6 +147,18 @@ migrate_systemd_system_conf() {
     fi
 }
 
+is_installable() {
+    dpkg-query --show "$1" > /dev/null 2>&1
+}
+
+apt_get_install_wazo_dbms() {
+    if is_installable wazo-dbms; then
+        apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends wazo-dbms
+    else
+        apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends xivo-dbms
+    fi
+}
+
 dist_upgrade() {
     differed_action pre-stop
     wazo-service stop
@@ -162,7 +174,7 @@ dist_upgrade() {
     apt-get update -qq
 
     apt-get install --yes -o Dpkg::Options::="--force-confnew" wazo-dist
-    apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends xivo-dbms  # Handle PostgreSQL cluster upgrade
+    apt_get_install_wazo_dbms # Handle PostgreSQL cluster upgrade
     apt-get install --yes -o Dpkg::Options::="--force-confnew" systemd systemd-sysv  # Fix rabbitmq-server.service obscure bug
     migrate_systemd_system_conf
     apt-get install --yes -o Dpkg::Options::="--force-confnew" rabbitmq-server


### PR DESCRIPTION
need to keep compatibility if option -t is used with archive
distribution