### PR TITLE
Pull request for WAZO-1534-fix-dbms-renaming

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -159,6 +159,14 @@ apt_get_install_wazo_dbms() {
     fi
 }
 
+apt_mark_auto_wazo_dbms() {
+    if is_available wazo-dbms; then
+        apt-mark auto wazo-dbms
+    else
+        apt-mark auto xivo-dbms
+    fi
+}
+
 dist_upgrade() {
     differed_action pre-stop
     wazo-service stop
@@ -178,7 +186,8 @@ dist_upgrade() {
     apt-get install --yes -o Dpkg::Options::="--force-confnew" systemd systemd-sysv  # Fix rabbitmq-server.service obscure bug
     migrate_systemd_system_conf
     apt-get install --yes -o Dpkg::Options::="--force-confnew" rabbitmq-server
-    apt-mark auto xivo-dbms systemd systemd-sysv rabbitmq-server
+    apt-mark auto systemd systemd-sysv rabbitmq-server
+    apt_mark_auto_wazo_dbms
     prepare_consul_upgrade
     apt-get upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get dist-upgrade --yes -o Dpkg::Options::="--force-confnew"

--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -147,12 +147,12 @@ migrate_systemd_system_conf() {
     fi
 }
 
-is_installable() {
-    dpkg-query --show "$1" > /dev/null 2>&1
+is_available() {
+    apt-cache show "$1" > /dev/null 2>&1
 }
 
 apt_get_install_wazo_dbms() {
-    if is_installable wazo-dbms; then
+    if is_available wazo-dbms; then
         apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends wazo-dbms
     else
         apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends xivo-dbms


### PR DESCRIPTION
## upgrade-buster: fix condition to check if dbms is installable

why: dpkg-query wasn't working.
apt-cache will return error code if package is not available

## upgrade-buster: mark dbms auto according xivo or wazo