### PR TITLE
buster: remove dahdi upgrade

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 LOGFILE="/var/log/wazo-upgrade.log"
@@ -121,13 +121,6 @@ EOF
     chown consul: /var/lib/consul/raft/peers.json
 }
 
-upgrade_dahdi_linux_modules() {
-    kernel_release=$(ls /lib/modules/ | grep "^4\.19\.")
-    for kr in $kernel_release; do
-        apt-get install --yes -o Dpkg::Options::="--force-confnew" dahdi-linux-modules-${kr}
-    done
-}
-
 change_sources_list() {
     from=$1
     to=$2
@@ -185,8 +178,6 @@ dist_upgrade() {
     apt-get upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get dist-upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get autoremove --yes
-
-    upgrade_dahdi_linux_modules
 
     differed_action pre-start
     wazo-service enable


### PR DESCRIPTION
why: latest buster version doesn't support dahdi anymore