### PR TITLE
bullseye: fix sed to match any security url

### DIFF
--- a/bin/wazo-dist-upgrade-bullseye-base
+++ b/bin/wazo-dist-upgrade-bullseye-base
@@ -74,9 +74,9 @@ change_sources_list() {
     from=$1
     to=$2
     if [ ${from} == 'buster' ] && [ ${to} == 'bullseye' ]; then
-        sed -i "s|debian-security buster/updates|debian-security bullseye-security|" /etc/apt/sources.list
+        sed -i "s|\(security.*\) buster/updates|\1 bullseye-security|" /etc/apt/sources.list
     elif [ ${from} == 'bullseye' ] && [ ${to} == 'buster' ]; then
-        sed -i "s|debian-security bullseye-security|debian-security buster/updates|" /etc/apt/sources.list
+        sed -i "s|\(security.*\) bullseye-security|\1 buster/updates|" /etc/apt/sources.list
     fi
     sed -i "s/$from/$to/" /etc/apt/sources.list
 }


### PR DESCRIPTION
why: install may have different pattern for security mirror ex:
- deb https://deb.debian.org/debian-security bullseye-security main contrib
- deb https://security.debian.org/ bullseye-security main contrib