### PR TITLE
bullseye: migrate systemd file before upgrade

### DIFF
--- a/bin/wazo-dist-upgrade-bullseye-base
+++ b/bin/wazo-dist-upgrade-bullseye-base
@@ -123,9 +123,13 @@ dist_upgrade() {
     fi
 
     apt-get install --yes -o Dpkg::Options::="--force-confnew" --no-install-recommends wazo-dbms  # Handle PostgreSQL cluster upgrade
-    migrate_systemd_system_conf
     apt-get install --yes -o Dpkg::Options::="--force-confnew" rabbitmq-server
     apt-mark auto wazo-dbms rabbitmq-server
+
+    apt-get install --yes -o Dpkg::Options::="--force-confnew" systemd systemd-sysv
+    migrate_systemd_system_conf
+    apt-mark auto systemd systemd-sysv
+
     apt-get upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get dist-upgrade --yes -o Dpkg::Options::="--force-confnew"
     apt-get autoremove --yes


### PR DESCRIPTION
why: If systemd system.conf file is not migrated, wazo-uuid will
regenerate another UUID in its postinst

Also we need to migrate systemd BEFORE wazo-uuid to avoid this behavior