### PR TITLE
WAZO-3239 Support archive mirrors for stretch upgrade path

### DIFF
--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -144,11 +144,11 @@ EOF
         sed -i "/\(deb\.debian\.org.*) buster.*/d" /etc/apt/sources.list
         sed -i "/\(security\.debian\.org.*\) buster.*/d" /etc/apt/sources.list
         cat >> /etc/apt/sources.list <<EOF
-deb http://archive.debian.org/debian-archive/debian/ stretch main
-deb-src http://archive.debian.org/debian-archive/debian/ stretch main
+deb http://archive.debian.org/debian/ stretch main
+deb-src http://archive.debian.org/debian/ stretch main
 
-deb http://archive.debian.org/debian-archive/debian/ stretch-backports main
-deb-src http://archive.debian.org/debian-archive/debian/ stretch-backports main
+deb http://archive.debian.org/debian/ stretch-backports main
+deb-src http://archive.debian.org/debian/ stretch-backports main
 EOF
     fi
     sed -i "s/$from/$to/" /etc/apt/sources.list

--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -131,14 +131,14 @@ change_sources_list() {
 deb http://deb.debian.org/debian buster main
 deb-src http://deb.debian.org/debian buster main
 
-deb http://security.debian.org/debian-security buster main
-deb-src http://security.debian.org/debian-security buster main
+deb http://security.debian.org/debian-security buster/updates main
+deb-src http://security.debian.org/debian-security buster/updates main
 
 deb http://deb.debian.org/debian buster-updates main
 deb-src http://deb.debian.org/debian buster-updates main
 EOF
     elif [ ${from} == 'buster' ] && [ ${to} == 'stretch' ]; then
-        sed -i "/\(deb\.debian\.org.*) buster.*/d" /etc/apt/sources.list
+        sed -i "/\(deb\.debian\.org.*\) buster.*/d" /etc/apt/sources.list
         sed -i "/\(security\.debian\.org.*\) buster.*/d" /etc/apt/sources.list
         cat >> /etc/apt/sources.list <<EOF
 deb http://archive.debian.org/debian/ stretch main

--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -136,9 +136,6 @@ deb-src http://security.debian.org/debian-security buster main
 
 deb http://deb.debian.org/debian buster-updates main
 deb-src http://deb.debian.org/debian buster-updates main
-
-deb http://deb.debian.org/debian buster-backports main
-deb-src http://deb.debian.org/debian buster-backports main
 EOF
     elif [ ${from} == 'buster' ] && [ ${to} == 'stretch' ]; then
         sed -i "/\(deb\.debian\.org.*) buster.*/d" /etc/apt/sources.list
@@ -146,9 +143,6 @@ EOF
         cat >> /etc/apt/sources.list <<EOF
 deb http://archive.debian.org/debian/ stretch main
 deb-src http://archive.debian.org/debian/ stretch main
-
-deb http://archive.debian.org/debian/ stretch-backports main
-deb-src http://archive.debian.org/debian/ stretch-backports main
 EOF
     fi
     sed -i "s/$from/$to/" /etc/apt/sources.list

--- a/bin/wazo-dist-upgrade-buster
+++ b/bin/wazo-dist-upgrade-buster
@@ -124,6 +124,33 @@ EOF
 change_sources_list() {
     from=$1
     to=$2
+    if [ ${from} == 'stretch' ] && [ ${to} == 'buster' ]; then
+        sed -i "/\(security.*\) stretch.*/d" /etc/apt/sources.list
+        sed -i "/\(archive.*\) stretch.*/d" /etc/apt/sources.list
+        cat >> /etc/apt/sources.list <<EOF
+deb http://deb.debian.org/debian buster main
+deb-src http://deb.debian.org/debian buster main
+
+deb http://security.debian.org/debian-security buster main
+deb-src http://security.debian.org/debian-security buster main
+
+deb http://deb.debian.org/debian buster-updates main
+deb-src http://deb.debian.org/debian buster-updates main
+
+deb http://deb.debian.org/debian buster-backports main
+deb-src http://deb.debian.org/debian buster-backports main
+EOF
+    elif [ ${from} == 'buster' ] && [ ${to} == 'stretch' ]; then
+        sed -i "/\(deb\.debian\.org.*) buster.*/d" /etc/apt/sources.list
+        sed -i "/\(security\.debian\.org.*\) buster.*/d" /etc/apt/sources.list
+        cat >> /etc/apt/sources.list <<EOF
+deb http://archive.debian.org/debian-archive/debian/ stretch main
+deb-src http://archive.debian.org/debian-archive/debian/ stretch main
+
+deb http://archive.debian.org/debian-archive/debian/ stretch-backports main
+deb-src http://archive.debian.org/debian-archive/debian/ stretch-backports main
+EOF
+    fi
     sed -i "s/$from/$to/" /etc/apt/sources.list
 }
 


### PR DESCRIPTION
Will require backporting to enable upgrade path from 19.12 stacks.